### PR TITLE
Use power state from event instead of making network request when republishing power update event

### DIFF
--- a/protocol/v2/device/group.go
+++ b/protocol/v2/device/group.go
@@ -115,11 +115,8 @@ func (g *Group) addDeviceSubscription(dev GenericDevice) error {
 						continue
 					}
 				case common.EventUpdatePower:
-					state, err := g.GetPower()
-					if err != nil {
-						continue
-					}
-					err = g.publish(common.EventUpdatePower{Power: state})
+					ev := event.(common.EventUpdatePower)
+					err = g.publish(common.EventUpdatePower{Power: ev.Power})
 					if err != nil {
 						continue
 					}


### PR DESCRIPTION
This fixes an issue where setting the power state of a light to `false` results in reseting power to `true` again.

So this happened.
1. The physical device has the power state set to `true`.
2. Set the power to `false` using `Device::SetPower(false)` which sends an network request to the device accordingly.
3. Inside `Group::addDeviceSubscription()` the event `common.EventUpdatePower` is handled where `Device::GetPower()` is called. 
4. Inside `Device::GetPower()` the power state is fetched using a network request. But at this point the physical device didn't finish processing the previously made power state change request and therefore power is `true`. The power state is set using `Device::SetStatePower(true)` and an event is emitted.

The fix is to not request the power state but to use the value stored in the `EventUpdatePower.Power` field.
