### PR TITLE
Expose UDP listen address in protocol structure

### DIFF
--- a/protocol/v2.go
+++ b/protocol/v2.go
@@ -13,6 +13,8 @@ import (
 
 // V2 implements the LIFX LAN protocol version 2.
 type V2 struct {
+	// IP determines UDP IP for this protocol instance
+	IP net.IP
 	// Port determines UDP port for this protocol instance
 	Port int
 	// Reliable enables reliable comms, requests ACKs for all operations to
@@ -47,7 +49,7 @@ func (p *V2) init() error {
 	if p.Port == 0 {
 		p.Port = shared.DefaultPort
 	}
-	socket, err := net.ListenUDP(`udp4`, &net.UDPAddr{Port: p.Port})
+	socket, err := net.ListenUDP(`udp4`, &net.UDPAddr{IP: p.IP, Port: p.Port})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The machine I run [brutella/hklifx](https://github.com/brutella/hklifx) on has multiple interfaces for different VLANs. While golifx listens on all interfaces, golifx skips all messages sent by LIFX bulbs because it identifies them as having a non-local source. Configuring the UDP listen to the server’s interface with an IP in the bulbs’ network, fixes this.