### PR TITLE
Fix for new uuid version

### DIFF
--- a/common/subscription.go
+++ b/common/subscription.go
@@ -65,8 +65,13 @@ func (s *Subscription) Close() error {
 
 // newSubscription instantiates a new Subscription
 func newSubscription(provider *SubscriptionProvider) *Subscription {
+	u, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+
 	return &Subscription{
-		id:       uuid.NewV4(),
+		id:       u,
 		events:   make(chan interface{}, subscriptionChanSize),
 		quitChan: make(chan struct{}),
 		provider: provider,


### PR DESCRIPTION
Attempting to build is currently throwing the following message.

```bash
# github.com/pdf/golifx/common
common/subscription.go:69:23: multiple-value uuid.NewV4() in single-value context
```

The interface of the `satori/go.uuid` package changed such that there is the potential to return an error. I've made the code simply panic in this case as this is something that should basically never happen unless the random number generator fails - in which case you likely have bigger problems.